### PR TITLE
Adding Data Bag Encrypt/Decrypt for Knife

### DIFF
--- a/.chef/plugins/knife/data_bag_decrypt.rb
+++ b/.chef/plugins/knife/data_bag_decrypt.rb
@@ -1,0 +1,34 @@
+require "chef/knife"
+require_relative "data_bag_helpers"
+
+class Chef::Knife::DataBagDecrypt < Chef::Knife
+  include Chef::Knife::DataBagHelpers
+
+  banner "knife data bag decrypt DATA_BAG ITEM (options)"
+  category "data bag"
+
+  option :write, short: "-w", long: "--write", boolean: true, default: false
+
+  def run
+    data_bag, item = @name_args
+    plain_text_bag = read_item(data_bag, item)
+
+    if config[:write]
+      path = bag_item_path(data_bag, item)
+      json = JSON.pretty_generate(plain_text_bag.to_hash)
+      File.open(path, "w") { |file| file.write(json) }
+      output(json)
+    else
+      output(format_for_display(plain_text_bag))
+    end
+  end
+
+  private
+
+  def read_item(data_bag, data_bag_item)
+    raw = JSON.parse(File.read(bag_item_path(data_bag, data_bag_item)))
+    bag = Chef::DataBagItem.from_hash(raw)
+
+    Chef::EncryptedDataBagItem.new(bag, read_secret)
+  end
+end

--- a/.chef/plugins/knife/data_bag_encrypt.rb
+++ b/.chef/plugins/knife/data_bag_encrypt.rb
@@ -1,0 +1,33 @@
+require "chef/knife"
+require_relative "data_bag_helpers"
+
+class Chef::Knife::DataBagEncrypt < Chef::Knife
+  include Chef::Knife::DataBagHelpers
+
+  banner "knife data bag encrypt DATA_BAG ITEM (options)"
+  category "data bag"
+
+  option :write, short: "-w", long: "--write", boolean: true, default: false
+
+  def run
+    data_bag, item = @name_args
+    cipher_text_bag = read_item(data_bag, item)
+
+    if config[:write]
+      path = bag_item_path(data_bag, item)
+      json = JSON.pretty_generate(cipher_text_bag.to_hash)
+      File.open(path, "w") { |file| file.write(json) }
+      output(json)
+    else
+      output(format_for_display(cipher_text_bag))
+    end
+  end
+
+  private
+
+  def read_item(data_bag, data_bag_item)
+    raw = JSON.parse(File.read(bag_item_path(data_bag, data_bag_item)))
+    bag = Chef::DataBagItem.from_hash(raw)
+    Chef::EncryptedDataBagItem.encrypt_data_bag_item(bag, read_secret)
+  end
+end

--- a/.chef/plugins/knife/data_bag_helpers.rb
+++ b/.chef/plugins/knife/data_bag_helpers.rb
@@ -1,0 +1,11 @@
+module Chef::Knife::DataBagHelpers
+  private
+
+  def read_secret
+    Chef::EncryptedDataBagItem.load_secret(Chef::Config[:encrypted_data_bag_secret])
+  end
+
+  def bag_item_path(data_bag, data_bag_item)
+    File.join(Chef::Config[:data_bag_path], data_bag, "#{data_bag_item}.json")
+  end
+end

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@
 ###
 # Ignore Chef key files and secrets
 ###
-.chef/
+.chef/encrypted_data_bag_secret
+.chef/syntax_check_cache
+.chef/trusted_certs
+.chef/*.rb
+.chef/*.pem
+
 .kitchen/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,30 @@ The config file, `.chef/knife.rb` is a repository specific configuration file fo
 
 http://docs.chef.io/knife.html
 
-Next Steps
+Data Bags
 ==========
 
-Read the README file in each of the subdirectories for more information about what goes in those directories.
+Normally chef works by communicating directly with the server for data bags. However, I'd prefer to store these in
+json files within the repo.
+
+I've added `knife data bag encrypt` and `knife data bag decrypt` as knife plugins in this repo. Both of these commands
+use the `encrypted_data_bag_secret` setting defined in _.chef/knife.rb_ to handle encryption.
+
+## Creating a New Data Bag
+
+* Create a json file for the item (e.g. _data_bags/[BAG_NAME]/[ITEM].json_)
+* Add any plain text entries needed
+* Run `knife data bag encrypt [BAG_NAME] [ITEM] -w` (The `-w` means write to disk)
+* `knife data bag from file data_bags/[BAG_NAME]/[ITEM].json`
+
+## Editing a Data Bag
+
+* Decrypt the file with `knife data bag decrypt [BAG_NAME] [ITEM] -w`
+* Update the JSON file as needed
+* Encrypt the file `knife data bag encrypt [BAG_NAME] [ITEM] -w`
+* `knife data bag from file data_bags/[BAG_NAME]/[ITEM].json`
+
+## Deleting a Data Bag
+
+* `git rm data_bags/[BAG_NAME]/[ITEM].json`
+* `knife data bag delete BAG_NAME ITEM`


### PR DESCRIPTION
# The Problem

I don't like that data bags live in the ether. I'd rather work with json files in the local repo. However, this means I need an easy way to encrypt/decrypt data bags.
# The Solution

I've added two custom data bag commands: encrypt and decrypt.
- `knife data bag encrypt <bag> <item> -w` - encrypt the item and overwrite the file (`-w` means write)
- `knife data bag decrypt <bag> <item>` - decrypts the item and prints to STDOUT (use `-w` if you want to write the decrypted file)
